### PR TITLE
Use TestFile from PackageInfo.g as fallback

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,9 +40,24 @@ runs:
              GAP="$GAP --cover ${COVDIR-coverage}/$(mktemp XXXXXX).coverage"
          fi
 
-         # TODO: honor TestFile from PackageInfo record, but make sure that it
-         # is for the package in the current directory
-         $GAP ${GAP_TESTFILE:-tst/testall.g}
+         cat > __TEST_RUNNNER__.g <<EOF
+
+         GAP_TESTFILE:="";
+         Read("PackageInfo.g");
+         info := GAPInfo.PackageInfoCurrent;
+         if IsEmpty(GAP_TESTFILE) or not IsExistingFile(GAP_TESTFILE) then
+             GAP_TESTFILE := info.TestFile;
+         fi;
+         if EndsWith(GAP_TESTFILE, ".tst") then
+             SetPackagePath(info.PackageName, "$PWD");
+             LoadPackage(info.PackageName);
+             QUIT_GAP(Test(GAP_TESTFILE, rec(compareFunction := "uptowhitespace")));
+         else
+             Read(GAP_TESTFILE);
+             Error("Package TestFile did not exit gap");
+         fi;
+         EOF
+         $GAP __TEST_RUNNNER__.g
 
         env:
           NO_COVERAGE: ${{ inputs.NO_COVERAGE }}


### PR DESCRIPTION
... if GAP_TESTFILE is not set. Also handle .tst files correctly.

Note that right now `GAP_TESTFILE` has a default value `tst/testall.g`.
In the future, we should consider dropping this default value, and
packages which for some reason want to use a different testfile in CI
versus what is specified in `PackageInfo.g` must then set `GAP_TESTFILE`
explicitly. But I'd rather not do this at the same time as introducing
this change.


I am testing this right now at https://github.com/fingolfin/simpcomp/runs/5499938248?check_suite_focus=true