### PR TITLE
Actually honor GAP_TESTFILE, switch its default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,9 @@ inputs:
     required: false
     default: ''
   GAP_TESTFILE:
-    description: 'The name of the GAP file to be read for executing the package tests'
+    description: 'Name of the GAP file to be read for executing the package tests (overrides TestFile in PackageInfo.g)'
     required: false
-    default: 'tst/testall.g'
+    default: ''
 env:
   CHERE_INVOKING: 1
 
@@ -35,14 +35,14 @@ runs:
 
          # Unless explicitly turned off by setting the NO_COVERAGE environment variable,
          # we collect coverage data
-         if [[ -z $NO_COVERAGE ]]; then
+         if [[ -z "${{ inputs.NO_COVERAGE }}" ]]; then
              mkdir -p ${COVDIR-coverage}
              GAP="$GAP --cover ${COVDIR-coverage}/$(mktemp XXXXXX).coverage"
          fi
 
          cat > __TEST_RUNNNER__.g <<EOF
 
-         GAP_TESTFILE:="";
+         GAP_TESTFILE:="${{ inputs.GAP_TESTFILE }}";
          Read("PackageInfo.g");
          info := GAPInfo.PackageInfoCurrent;
          if IsEmpty(GAP_TESTFILE) or not IsExistingFile(GAP_TESTFILE) then
@@ -59,7 +59,4 @@ runs:
          EOF
          $GAP __TEST_RUNNNER__.g
 
-        env:
-          NO_COVERAGE: ${{ inputs.NO_COVERAGE }}
-          GAP_TESTFILE: ${{ inputs.GAP_TESTFILE }}
         shell: bash


### PR DESCRIPTION
By accident the value of the GAP_TESTFILE input was completely ignored. Nobody
noticed, however, because the only packages using it have set it to the
TestFile value in their PackageInfo.g anyway. So we may as well use this
opportunity to also change its default value to an empty string

Resolves #13