### PR TITLE
Fix regression for autoloaded packages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,8 +48,9 @@ runs:
          if IsEmpty(GAP_TESTFILE) or not IsExistingFile(GAP_TESTFILE) then
              GAP_TESTFILE := info.TestFile;
          fi;
+         # Load the package with debug info
          SetInfoLevel(InfoPackageLoading, PACKAGE_DEBUG);
-         SetPackagePath(info.PackageName, "$PWD");
+         SetPackagePath(info.PackageName, "/tmp/gaproot/pkg/$(basename $PWD)");
          LoadPackage(info.PackageName);
          SetInfoLevel(InfoPackageLoading, PACKAGE_ERROR);
          if EndsWith(GAP_TESTFILE, ".tst") then


### PR DESCRIPTION
Some packages are autoloaded by GAP during startup. For these, the call to
`SetPackagePath` may fail for a silly reason: GAP compares it to the path of
the currently loaded version, and if they differ, prints an error. We give GAP
`$PWD` as path of the package; but in practice, GAP already loaded it from
`/tmp/gaproot/PackageName`. So use that as path instead.
