### PR TITLE
Add `GAP_FLAGS` to list of inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     type: boolean
     default: false
   GAP_FLAGS:
-    description: 'Command line flags (and possibly there arguments) to pass to gap'
+    description: 'Command line flags (and possibly their arguments) to pass to gap'
     required: false
     type: string
     default: ''

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,12 @@ inputs:
     required: false
     type: boolean
     default: false
+  GAP_FLAGS:
+    description: 'Command line flags (and possibly there arguments) to pass to gap'
+    required: false
+    type: string
+    default: ''
+
 env:
   CHERE_INVOKING: 1
 
@@ -43,6 +49,7 @@ runs:
          if ${{ inputs.only-needed }} = 'true' ; then
            GAP="$GAP -A"
          fi
+         GAP="$GAP ${{ inputs.GAP_FLAGS }}"
 
          # Unless explicitly turned off by setting the NO_COVERAGE environment variable,
          # we collect coverage data


### PR DESCRIPTION
I wonder if it would be a good idea to check whether or not the inputs `only-needed` is true and `GAP_FLAGS` contains `-A` would be a good idea. I also haven't tested this at all, I'm not sure how to, hopefully there's some ci here?