### PR TITLE
Add `pre-gap` and `warnings-as-errors` option

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,18 +12,32 @@ env:
 
 jobs:
   test:
-    name: ${{ matrix.no-coverage }} ${{ matrix.testfile }}
+    name: "${{ matrix.no-coverage }} ${{ matrix.testfile }} ${{ matrix.pre-gap == 'time' && 'pre-gap: time' || ' ' }} ${{ matrix.warn && 'warnings-as-errors' || ' ' }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         no-coverage: ['']
         testfile: ['']
+        warn: [false]
+        pre-gap: ['']
         include:
           - no-coverage: 'no-coverage'
             testfile: ''
+            warn: false
+            pre-gap: ''
           - no-coverage: ''
             testfile: 'tst/testall.g'
+            warn: false
+            pre-gap: ''
+          - no-coverage: ''
+            testfile: ''
+            warn: true
+            pre-gap: ''
+          - no-coverage: ''
+            testfile: ''
+            warn: false
+            pre-gap: 'time'
 
     steps:
       # the order of the checkout actions is important because all contents of
@@ -44,3 +58,5 @@ jobs:
         with:
           NO_COVERAGE: ${{ matrix.no-coverage }}
           GAP_TESTFILE: ${{ matrix.testfile }}
+          warnings-as-errors: ${{ matrix.warn }}
+          pre-gap: ${{ matrix.pre-gap }}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ All of the following inputs are optional.
     setting this to `valgrind --trace-children=yes --leak-check=full` will run
     GAP through valgrind)'
   - default: `''`
+- `warnings-as-errors`:
+  - Set to `true` to treat warnings produced when loading the package as errors.
+  - default: `false`
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ All of the following inputs are optional.
 - `GAP_TESTFILE`:
   - The name of the GAP file to be read for executing the package tests.
   - default: `'tst/testall.g'`
+- `pre-gap`:
+  - Prefix for the `GAP` shell variable used by this action to launch GAP (e.g.
+    setting this to `valgrind --trace-children=yes --leak-check=full` will run
+    GAP through valgrind)'
+  - default: `''`
 
 ### Example
 
@@ -46,10 +51,12 @@ jobs:
 ```
 
 ## Contact
+
 Please submit bug reports, suggestions for improvements and patches via
 the [issue tracker](https://github.com/gap-actions/run-pkg-tests/issues).
 
 ## License
+
 The action `run-pkg-tests` is free software; you can redistribute
 and/or modify it under the terms of the GNU General Public License as published
 by the Free Software Foundation; either version 2 of the License, or (at your

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
              GAP="${{ inputs.pre-gap }} $GAP"
          fi
 
-         if ${{ inputs.only-needed }} = 'true' ; then
+         if "${{ inputs.only-needed }}" = "true" ; then
            GAP="$GAP -A"
          fi
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,11 @@ inputs:
     required: false
     type: boolean
     default: false
+  pre-gap:
+    description: 'Prefix for the ''GAP'' shell variable used by this action to launch GAP (e.g. setting this to ''valgrind --trace-children=yes --leak-check=full'' will run GAP through valgrind)'
+    required: false
+    type: string
+    default: ''
 env:
   CHERE_INVOKING: 1
 
@@ -44,6 +49,11 @@ runs:
 
          # start GAP with custom GAP root, to ensure correct package version is loaded
          GAP="$GAPROOT/gap -l /tmp/gaproot; --quitonbreak"
+
+         # Prepend pre-gap prefix, if it exists
+         if [[ ! -z "${{ inputs.pre-gap }}" ]]; then
+             GAP="${{ inputs.pre-gap }} $GAP"
+         fi
 
          if ${{ inputs.only-needed }} = 'true' ; then
            GAP="$GAP -A"

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,11 @@ inputs:
     required: false
     type: boolean
     default: false
+  warnings-as-errors:
+    description: 'If set to true then any errors produced whilst loading the package will be treated as errors'
+    required: false
+    type: boolean
+    default: false
   pre-gap:
     description: 'Prefix for the ''GAP'' shell variable used by this action to launch GAP (e.g. setting this to ''valgrind --trace-children=yes --leak-check=full'' will run GAP through valgrind)'
     required: false
@@ -74,9 +79,17 @@ runs:
          if IsEmpty(GAP_TESTFILE) or not IsExistingFile(GAP_TESTFILE) then
              GAP_TESTFILE := info.TestFile;
          fi;
-         # Load the package with debug info
+
          SetInfoLevel(InfoPackageLoading, PACKAGE_DEBUG);
          SetPackagePath(info.PackageName, "/tmp/gaproot/pkg/$(basename $PWD)");
+
+         # Capture the output of loading
+         output := "";
+         output_stream := OutputTextString(output, true);
+         SetPrintFormattingStatus(output_stream, false);
+         OutputLogTo(output_stream);
+
+         # Load the package with debug info
          if ${{ inputs.only-needed }} = true then
             LoadPackage(info.PackageName : OnlyNeeded);
          else
@@ -85,6 +98,17 @@ runs:
          if ${{ inputs.load-all }} = true then
             LoadAllPackages();
          fi;
+
+         OutputLogTo();
+         CloseStream(output_stream);
+
+         # Treat warnings as errors if specified
+         if ${{ inputs.warnings-as-errors }} = true then
+            if PositionSublist(output, "warning") <> fail then
+                Error("Warnings were found when loading the package");
+            fi;
+         fi;
+
          SetInfoLevel(InfoPackageLoading, PACKAGE_ERROR);
          Print("Now running tests from ", GAP_TESTFILE, "\n");
          if EndsWith(GAP_TESTFILE, ".tst") then


### PR DESCRIPTION
This PR address #30 and #32, and supersedes #33 and #34, by adding two new options to the action. The `pre-gap` option is for specifying a prefix to the `GAP` shell variable, and the `warnings-as-errors` option treats any warnings produced during the loading of a package as an error.

The two of these concepts are currently present in the custom version of this action in the Digraphs package (see the [action file](https://github.com/Joseph-Edwards/Digraphs/blob/743a66162df84578cf870179633cd65c3b88bc4c/.github/actions/run-pkg-tests/action.yml)).

The changes present in this PR are tested by the CI, and also in [my fork of the example package](https://github.com/Joseph-Edwards/example). The source code of the example package is exactly the same as normal, with the addition of an unbound variable. In the workflow [CI (advanced)](https://github.com/Joseph-Edwards/example/actions/runs/13983530081), half of the jobs set `warnings-as-error` (and correctly fail), and the other half don't (and correctly pass). All off the tests specify the `'time'` for `pre-gap`, and subsequently the time to run the tests was correctly reported.