### PR TITLE
Rename `GAP_TESTFILE` input to `testfile`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   test:
-    name: "Test action (GAP_TESTFILE: '${{ matrix.testfile }}', mode: '${{ matrix.mode }}', NO_COVERAGE: '${{ matrix.no-coverage }}',  pre-gap: '${{ matrix.pre-gap }}',  warnings-as-errors: '${{ matrix.warn }})"
+    name: "Test action (testfile: '${{ matrix.testfile }}', mode: '${{ matrix.mode }}', NO_COVERAGE: '${{ matrix.no-coverage }}',  pre-gap: '${{ matrix.pre-gap }}',  warnings-as-errors: '${{ matrix.warn }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -76,12 +76,12 @@ jobs:
       - uses: ./this-action/
         with:
           NO_COVERAGE: ${{ matrix.no-coverage }}
-          GAP_TESTFILE: ${{ matrix.testfile }}
+          testfile: ${{ matrix.testfile }}
           warnings-as-errors: ${{ matrix.warn }}
           pre-gap: ${{ matrix.pre-gap }}
           mode: ${{ matrix.mode }}
   test-failure:
-    name: "Validate input (GAP_TESTFILE: '${{ matrix.testfile }}', mode: '${{ matrix.mode }}', NO_COVERAGE: '${{ matrix.no-coverage }}',  pre-gap: '${{ matrix.pre-gap }}',  warnings-as-errors: '${{ matrix.warn }})"
+    name: "Validate input (testfile: '${{ matrix.testfile }}', mode: '${{ matrix.mode }}', NO_COVERAGE: '${{ matrix.no-coverage }}',  pre-gap: '${{ matrix.pre-gap }}',  warnings-as-errors: '${{ matrix.warn }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -138,7 +138,7 @@ jobs:
       - uses: ./this-action/
         with:
           NO_COVERAGE: ${{ matrix.no-coverage }}
-          GAP_TESTFILE: ${{ matrix.testfile }}
+          testfile: ${{ matrix.testfile }}
           warnings-as-errors: ${{ matrix.warn }}
           pre-gap: ${{ matrix.pre-gap }}
           mode: ${{ matrix.mode }}

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ All of the following inputs are optional.
 - `NO_COVERAGE`:
   - Boolean that determines whether or not to suppress gathering coverage.
   - default: `'false'`
-- `GAP_TESTFILE`:
-  - Name of the GAP file to be read for executing the package tests (overrides TestFile in PackageInfo.g).
+- `testfile`:
+  - Name of the GAP file to be read for executing the package tests.
   - default: The `TestFile` specified in `PackageInfo.g`
 - `mode`:
   - Value that determines which packages are loaded before the package is tested. The possible values
@@ -37,8 +37,9 @@ All of the following inputs are optional.
 
 ### What's new in v4
 
-There are two main changes between v3 and v4: the introduction of the `mode`
-option, and the restriction of the allowed values for boolean-like options.
+There are several changes between v3 and v4: the introduction of the `mode` option,
+the renaming of the `GAP_TESTFILE` option to `testfile`,
+and the restriction of the allowed values for boolean-like options.
 
 #### The `mode` option
 

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'Boolean that determines whether or not to suppress gathering coverage'
     required: false
     default: 'false'
-  GAP_TESTFILE:
+  testfile:
     description: 'Name of the GAP file to be read for executing the package tests (overrides TestFile in PackageInfo.g)'
     required: false
     default: ''
@@ -84,7 +84,7 @@ runs:
 
          cat > __TEST_RUNNNER__.g <<EOF
 
-         GAP_TESTFILE:="${{ inputs.GAP_TESTFILE }}";
+         GAP_TESTFILE:="${{ inputs.testfile }}";
          Read("PackageInfo.g");
          info := GAPInfo.PackageInfoCurrent;
          if IsEmpty(GAP_TESTFILE) or not IsExistingFile(GAP_TESTFILE) then


### PR DESCRIPTION
I figured that if we are making a breaking change now anyway, this should be also changed.