### PR TITLE
Replace `NO_COVERAGE` by `coverage` input

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,48 +12,48 @@ env:
 
 jobs:
   test:
-    name: "Test action (testfile: '${{ matrix.testfile }}', mode: '${{ matrix.mode }}', NO_COVERAGE: '${{ matrix.no-coverage }}',  pre-gap: '${{ matrix.pre-gap }}',  warnings-as-errors: '${{ matrix.warn }})"
+    name: "Test action (testfile: '${{ matrix.testfile }}', mode: '${{ matrix.mode }}', coverage: '${{ matrix.coverage }}',  pre-gap: '${{ matrix.pre-gap }}',  warnings-as-errors: '${{ matrix.warn }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        no-coverage: ['false']
+        coverage: ['true']
         testfile: ['']
         warn: ['true']
         pre-gap: ['']
         mode: ['default']
         include:
-          # test no-coverage
-          - no-coverage: 'true'
+          # test coverage
+          - coverage: 'false'
             testfile: ''
             warn: 'true'
             pre-gap: ''
             mode: 'default'
           # test testfile
-          - no-coverage: 'false'
+          - coverage: 'true'
             testfile: 'tst/testall.g'
             warn: 'true'
             pre-gap: ''
             mode: 'default'
           # test warn
-          - no-coverage: 'false'
+          - coverage: 'true'
             testfile: ''
             warn: 'false'
             pre-gap: ''
             mode: 'default'
           # test pre-gap
-          - no-coverage: 'false'
+          - coverage: 'true'
             testfile: ''
             warn: 'true'
             pre-gap: 'time'
             mode: 'default'
           # test mode
-          - no-coverage: 'false'
+          - coverage: 'true'
             testfile: ''
             warn: 'true'
             pre-gap: ''
             mode: 'onlyneeded'
-          - no-coverage: 'false'
+          - coverage: 'true'
             testfile: ''
             warn: 'true'
             pre-gap: ''
@@ -75,49 +75,49 @@ jobs:
       - uses: gap-actions/build-pkg@v1
       - uses: ./this-action/
         with:
-          NO_COVERAGE: ${{ matrix.no-coverage }}
+          coverage: ${{ matrix.coverage }}
           testfile: ${{ matrix.testfile }}
           warnings-as-errors: ${{ matrix.warn }}
           pre-gap: ${{ matrix.pre-gap }}
           mode: ${{ matrix.mode }}
   test-failure:
-    name: "Validate input (testfile: '${{ matrix.testfile }}', mode: '${{ matrix.mode }}', NO_COVERAGE: '${{ matrix.no-coverage }}',  pre-gap: '${{ matrix.pre-gap }}',  warnings-as-errors: '${{ matrix.warn }})"
+    name: "Validate input (testfile: '${{ matrix.testfile }}', mode: '${{ matrix.mode }}', coverage: '${{ matrix.coverage }}',  pre-gap: '${{ matrix.pre-gap }}',  warnings-as-errors: '${{ matrix.warn }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        no-coverage: ['false']
+        coverage: ['true']
         testfile: ['']
         warn: ['true']
         pre-gap: ['']
         mode: ['default']
         include:
-          # test no-coverage
-          - no-coverage: 'nonsense'
+          # test coverage
+          - coverage: 'nonsense'
             testfile: ''
             warn: 'true'
             pre-gap: ''
             mode: 'default'
           # test warn
-          - no-coverage: 'false'
+          - coverage: 'true'
             testfile: ''
             warn: 'nonsense'
             pre-gap: ''
             mode: 'default'
           # test pre-gap
-          - no-coverage: 'false'
+          - coverage: 'true'
             testfile: ''
             warn: 'true'
             pre-gap: 'nonsense'
             mode: 'default'
           # test mode
-          - no-coverage: 'false'
+          - coverage: 'true'
             testfile: ''
             warn: 'true'
             pre-gap: ''
             mode: 'nonsense'
         exclude:
-          - no-coverage: 'false'
+          - coverage: 'true'
             testfile: ''
             warn: 'true'
             pre-gap: ''
@@ -137,7 +137,7 @@ jobs:
       - uses: gap-actions/build-pkg@v1
       - uses: ./this-action/
         with:
-          NO_COVERAGE: ${{ matrix.no-coverage }}
+          coverage: ${{ matrix.coverage }}
           testfile: ${{ matrix.testfile }}
           warnings-as-errors: ${{ matrix.warn }}
           pre-gap: ${{ matrix.pre-gap }}

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Its behaviour can be customized via the inputs below.
 
 All of the following inputs are optional.
 
-- `NO_COVERAGE`:
-  - Boolean that determines whether or not to suppress gathering coverage.
-  - default: `'false'`
+- `coverage`:
+  - Boolean that determines whether GAP is instructed to collect code coverage via the `--cover` argument.
+  - default: `'true'`
 - `testfile`:
   - Name of the GAP file to be read for executing the package tests.
   - default: The `TestFile` specified in `PackageInfo.g`
@@ -38,8 +38,16 @@ All of the following inputs are optional.
 ### What's new in v4
 
 There are several changes between v3 and v4: the introduction of the `mode` option,
-the renaming of the `GAP_TESTFILE` option to `testfile`,
+the renaming of some options,
 and the restriction of the allowed values for boolean-like options.
+
+#### Renamed options
+
+The `GAP_TESTFILE` input was renamed to `testfile`, with no functional changes.
+
+The `NO_COVERAGE` input was replaced by the `coverage` input with flipped
+meaning. Thus if you previously set `NO_COVERAGE` to `false` you should now
+set `coverage` to `true`.
 
 #### The `mode` option
 
@@ -62,9 +70,9 @@ with `mode: 'loadall'`.
 
 #### Restricted boolean-like options
 
-In v3, the boolean-like options `NO_COVERAGE` and `warnings-as-errors` accepted
-any string value. In v4, these options only accept the values `'true'` and
-`'false'`.
+In v3, the boolean-like options such as `warnings-as-errors` accepted
+any string value. In v4, they only accept the values `'true'` and
+`'false'`, anything else results in an error.
 
 ### What's new in v3
 

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
 name: 'Run package tests'
 description: 'Run package tests'
 inputs:
-  NO_COVERAGE:
-    description: 'Boolean that determines whether or not to suppress gathering coverage'
+  coverage:
+    description: 'Boolean that determines whether GAP is instructed to collect code coverage via the `--cover` argument'
     required: false
-    default: 'false'
+    default: 'true'
   testfile:
     description: 'Name of the GAP file to be read for executing the package tests (overrides TestFile in PackageInfo.g)'
     required: false
@@ -45,7 +45,7 @@ runs:
          }
 
          validate_mode
-         validate_boolean "${{ inputs.NO_COVERAGE }}" NO_COVERAGE
+         validate_boolean "${{ inputs.coverage }}" coverage
          validate_boolean "${{ inputs.warnings-as-errors }}" warnings-as-errors
 
       - name: "Run tests"
@@ -75,11 +75,11 @@ runs:
            GAP="$GAP -A"
          fi
 
-         # Unless explicitly turned off by setting the NO_COVERAGE environment variable,
+         # Unless explicitly turned off by setting the `coverage` input to `false`
          # we collect coverage data
-         if ! ${{ inputs.NO_COVERAGE }}; then
-             mkdir -p ${COVDIR-coverage}
-             GAP="$GAP --cover ${COVDIR-coverage}/$(mktemp XXXXXX).coverage"
+         if ${{ inputs.coverage }}; then
+             mkdir -p coverage
+             GAP="$GAP --cover coverage/$(mktemp XXXXXX).coverage"
          fi
 
          cat > __TEST_RUNNNER__.g <<EOF


### PR DESCRIPTION
Resolves #12

Also removes the undocumented `COVDIR` environment variable (see also https://github.com/gap-actions/process-coverage/pull/21).

See also https://github.com/gap-actions/build-pkg/pull/12