### PR TITLE
Require `setup-gap@v3` to simplify some code

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,9 +66,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: this-action/
-      - uses: gap-actions/setup-gap@v2
-        with:
-          GAP_PKGS_TO_BUILD: ''
+      - uses: gap-actions/setup-gap@v3
       - uses: gap-actions/build-pkg@v2
       - uses: ./this-action/
         with:
@@ -128,9 +126,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: this-action/
-      - uses: gap-actions/setup-gap@v2
-        with:
-          GAP_PKGS_TO_BUILD: ''
+      - uses: gap-actions/setup-gap@v3
       - uses: gap-actions/build-pkg@v2
       - uses: ./this-action/
         with:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ All of the following inputs are optional.
 ### What's new in v4
 
 There are several changes between v3 and v4: the introduction of the `mode` option,
-the renaming of some options,
+the renaming of some options, the requirement for using `gap-actions/setup-gap@v3` or newer
 and the restriction of the allowed values for boolean-like options.
 
 #### Renamed options

--- a/action.yml
+++ b/action.yml
@@ -53,20 +53,6 @@ runs:
       run: |
         set -ex
 
-        GAPROOT=${GAPROOT-$HOME/gap}
-
-        # set up a custom GAP root containing only this package, so that
-        # we can force GAP to load the correct version of this package
-        # (we already did that in build_pkg.sh, but we do it again here,
-        # to allow the occasional instance where a package wants to also
-        # run the tests of others packages, by invoking this script multiple
-        # times in different directories)
-        mkdir -p /tmp/gaproot/pkg/
-        ln -f -s $PWD /tmp/gaproot/pkg/
-
-        # start GAP with custom GAP root, to ensure correct package version is loaded
-        GAP="$GAPROOT/gap -l /tmp/gaproot; --quitonbreak"
-
         # Prepend pre-gap prefix, if it exists
         if [[ ! -z "${{ inputs.pre-gap }}" ]]; then
           GAP="${{ inputs.pre-gap }} $GAP"
@@ -96,7 +82,7 @@ runs:
         fi;
 
         SetInfoLevel(InfoPackageLoading, PACKAGE_DEBUG);
-        SetPackagePath(info.PackageName, "/tmp/gaproot/pkg/$(basename $PWD)");
+        SetPackagePath(info.PackageName, "$PWD");
 
         # Capture the output of loading
         output := "";


### PR DESCRIPTION
While this is not strictly necessary, I feel that if we release a breaking v4 soon anyway, we might as well do this now.

On the other hand, it will make the transition to the new version a bit harder because the user has to first upgrade to `setup-gap@v3`. But then we probably should do that automatically for everything in `gap-packages` anyway, with some scripts...