### PR TITLE
Add functionality to ignore warnings with particular prefixes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,16 +116,21 @@ runs:
          # Treat warnings as errors if specified
          ignored_prefixes := ["#I  HAP "];
          if ${{ inputs.warnings-as-errors }} then
-             pos := 0;
-             repeat
+             pos := PositionSublist(output, "warning");
+             while pos <> fail do
+                 warning := true;
                  for prefix in ignored_prefixes do
                      l := Length(prefix);
-                     if pos > l and output{[pos-l .. pos-1]} <> prefix then
-                         Error("Warnings were found when loading the package");
+                     if pos > l and output{[pos-l .. pos-1]} = prefix then
+                         warning := false;
+                         break;
                      fi;
                  od;
+                 if warning then
+                     Error("Warnings were found when loading the package");
+                 fi;
                  pos := PositionSublist(output, "warning", pos + 1);
-             until pos = fail;
+             od;
          fi;
 
          SetInfoLevel(InfoPackageLoading, PACKAGE_ERROR);

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
          fi
 
          if [ "${{ inputs.mode }}" = "onlyneeded" ]; then
-           GAP="$GAP -A"
+             GAP="$GAP -A"
          fi
 
          # Unless explicitly turned off by setting the `coverage` input to `false`
@@ -102,22 +102,30 @@ runs:
 
          # Load the package with debug info
          if "${{ inputs.mode }}" = "onlyneeded" then
-            LoadPackage(info.PackageName : OnlyNeeded);
+             LoadPackage(info.PackageName : OnlyNeeded);
          elif "${{ inputs.mode }}" = "loadall" then
-            LoadPackage(info.PackageName);
-            LoadAllPackages();
+             LoadPackage(info.PackageName);
+             LoadAllPackages();
          else
-            LoadPackage(info.PackageName);
+             LoadPackage(info.PackageName);
          fi;
 
          OutputLogTo();
          CloseStream(output_stream);
 
          # Treat warnings as errors if specified
+         ignored_prefixes := ["#I  HAP "];
          if ${{ inputs.warnings-as-errors }} then
-            if PositionSublist(output, "warning") <> fail then
-                Error("Warnings were found when loading the package");
-            fi;
+             pos := 0;
+             repeat
+                 for prefix in ignored_prefixes do
+                     l := Length(prefix);
+                     if pos > l and output{[pos-l .. pos-1]} <> prefix then
+                         Error("Warnings were found when loading the package");
+                     fi;
+                 od;
+                 pos := PositionSublist(output, "warning", pos + 1);
+             until pos = fail;
          fi;
 
          SetInfoLevel(InfoPackageLoading, PACKAGE_ERROR);


### PR DESCRIPTION
... and some minor indentation fixes.

Perhaps needs to be properly tested, but after a quick check it seems to work...