### PR TITLE
Update versions of actions in CI and README

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,10 +66,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: this-action/
-      - uses: gap-actions/setup-gap@v2
-        with:
-          GAP_PKGS_TO_BUILD: ''
-      - uses: gap-actions/build-pkg@v2
+      - uses: gap-actions/setup-gap@v3
+      - uses: gap-actions/build-pkg@v3
       - uses: ./this-action/
         with:
           coverage: ${{ matrix.coverage }}
@@ -128,10 +126,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: this-action/
-      - uses: gap-actions/setup-gap@v2
-        with:
-          GAP_PKGS_TO_BUILD: ''
-      - uses: gap-actions/build-pkg@v2
+      - uses: gap-actions/setup-gap@v3
+      - uses: gap-actions/build-pkg@v3
       - uses: ./this-action/
         with:
           coverage: ${{ matrix.coverage }}

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: gap-actions/setup-gap@v3
-      - uses: gap-actions/build-pkg@v2
+      - uses: gap-actions/build-pkg@v3
       - uses: gap-actions/run-pkg-tests@v4
 ```
 


### PR DESCRIPTION
Instead of the Dependabot PR's, since these updates should ideally happen together and we need to remove deprecated inputs...